### PR TITLE
Update specific source with version message

### DIFF
--- a/actions/nix/update-nix-sources/update-nix-sources.py
+++ b/actions/nix/update-nix-sources/update-nix-sources.py
@@ -218,10 +218,32 @@ def gh_add_pr_reviwers(pr_id: str, users: List[str]) -> None:
   typer.echo(response["data"])
 
 
+# --- Nix functions
 
 def niv(*cmd: str) -> None:
     cmds = ["niv"] + list(cmd)
     subprocess.run(cmds, check=True)
+
+
+class NivSourceInfo(NamedTuple):
+  name: str
+  repo: str
+  branch: str
+  rev: str
+
+def get_source_info(name: str, niv_path: str = 'nix/sources.json')
+  """ Get information about a nix source """
+  
+  with open(niv_path, 'r') as f:
+    d = json.load(f)
+  
+  info = NivSourceInfo(
+    name=d[name]['name'],
+    repo=d[name]['repo'],
+    branch=d[name]['branch'],
+    rev=d[name]['rev'],
+  )
+  return info
 
 
 def main(

--- a/actions/nix/update-nix-sources/update-nix-sources.py
+++ b/actions/nix/update-nix-sources/update-nix-sources.py
@@ -186,19 +186,20 @@ def gh_add_pr_reviwers(pr_id: str, users: List[str]) -> None:
 
 
 
-def niv(cmd:str) -> None:
-  subprocess.run(["niv", cmd], check=True)
-
+def niv(*cmd: str) -> None:
+    cmds = ["niv"] + list(cmd)
+    subprocess.run(cmds, check=True)
 
 
 def main(
   branch:str = "bot/update-nix-sources",
   pr_title:str = "[bot] Update nix sources",
-  pr_body:str = "This is a automatic generatet PR, with updates to nix sources.",
-  commiter_username:str = "GitHub",
-  commiter_email:str = "noreply@github.com",
+  pr_body:str = "This is a automatic generated PR, with updates to nix sources.",
+  commiter_username: str = "GitHub",
+  commiter_email: str = "noreply@github.com",
   github_token: Optional[str] = typer.Argument(None, envvar="GITHUB_TOKEN"),
   reviewer: Optional[List[str]] = typer.Option(None),
+  source: Optional[str] = typer.Option(None, help='Specific source to update, if omitted updates all'),
 ):
   if github_token is None:
       typer.secho("# >>> GITHUB TOKEN MISSING: Add token to cli arg github_token or set env variable GITHUB_TOKEN", fg=typer.colors.RED)
@@ -215,7 +216,11 @@ def main(
   git_commit(commiter_username, commiter_email, "Update sources.nix")
 
   typer.secho("\n# >>> Update nix sources", fg=typer.colors.BLUE)
-  niv("update")
+  if source is not None:
+      niv("update", source)
+  else:
+      niv("update") # Update all sources
+
   git_add()
   git_commit(commiter_username, commiter_email, "Update nix sources")
 

--- a/actions/nix/update-nix-sources/update-nix-sources.py
+++ b/actions/nix/update-nix-sources/update-nix-sources.py
@@ -218,11 +218,13 @@ def main(
   typer.secho("\n# >>> Update nix sources", fg=typer.colors.BLUE)
   if source is not None:
       niv("update", source)
+      commit_msg = f'Update nix sources {source}'
   else:
       niv("update") # Update all sources
+      commit_msg = 'Update nix sources'
 
   git_add()
-  git_commit(commiter_username, commiter_email, "Update nix sources")
+  git_commit(commiter_username, commiter_email, commit_msg)
 
   typer.secho("\n# >>> Force push", fg=typer.colors.BLUE)
   git_force_push(branch)


### PR DESCRIPTION
- Legge til source option i update-nix-sources action for å oppgradere spesifikk ressurs
- Hente info om spesifikk ressurs versjon før og etter update for å inkludere i commit message

Bruker `rev` i `nix/sources.json` og sjekker de siste tag'ene som noen av de peker til `rev`. Tagnavn brukes da til versjonsnavn. Hvis vi ikke finner noen tags som peker til `rev` bruker vi `rev` som versjonsnavn.

Merge conflictene er sikkert fordi jeg rebaset osv, så da er vel bare å overskrive med denne greinen når den er slik vi vil ha den?